### PR TITLE
chore: finish phase 0 environment and stabilization goals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /go/src/k8s-vault-webhook/
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module k8s-vault-webhook
 
-go 1.16
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go v1.38.17
 	github.com/docker/docker v20.10.5+incompatible
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -18,4 +16,59 @@ require (
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0
 	sigs.k8s.io/controller-runtime v0.8.3
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v0.0.0-20171011171712-7484e51bf6af // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.18.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	gomodules.xyz/jsonpatch/v3 v3.0.1 // indirect
+	gomodules.xyz/orderedmap v0.1.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,6 @@ github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/main.go
+++ b/main.go
@@ -213,8 +213,8 @@ func (mw *mutatingWebhook) lookForEnvFrom(envFrom []corev1.EnvFromSource, ns str
 
 func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSpec *corev1.PodSpec, secretManagerConfig secretManagerConfig, ns string) (bool, error) {
 	mutated := false
-	var mutationInProgress bool
 	for i, container := range containers {
+		var mutationInProgress bool
 		var envVars []corev1.EnvVar
 		if len(container.EnvFrom) > 0 {
 			envFrom, err := mw.lookForEnvFrom(container.EnvFrom, ns) //nolint

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestWebhookMutations(t *testing.T) {
+	// TODO: Add tests for mutationInProgress bug and other webhook features
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strings"
 	"time"
@@ -138,7 +138,7 @@ func getImageBlob(container ContainerInfo) (*imagev1.ImageConfig, error) {
 
 	defer reader.Close()
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read blob: %s", err.Error())
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,7 @@
+package registry
+
+import "testing"
+
+func TestRegistry(t *testing.T) {
+	// TODO: Add tests for registry credential fetching and caching
+}


### PR DESCRIPTION
# 🎯 Objective
This Pull Request covers Phase 0 of the Winter of Code project for **k8s-vault-webhook**. It addresses critical stabilization bugs, eliminates technical debt, and modernizes the Go tooling environment to prepare the repository for the upcoming core architecture refactor (Phase 1).

# 🛠️ Changes Made
## 1. Bug Fix: `mutationInProgress` Variable Leak

**Files involved:**
- `main.go`

**Issue:**
The `mutationInProgress` boolean flag was declared outside the container loop in `mutateContainers`. In multi-container pods, if the first container triggered a mutation, the flag remained set to true, erroneously applying provider validation/arguments to subsequent, unannotated containers.

**Fix:**
Moved the variable declaration inside the `for _, container := range containers` loop to correctly scope the state per container.

## 2. Go Modernization
**Files involved:**
- `go.mod`
- `Dockerfile`

- Updated the Go version in `go.mod` from 1.16 to 1.23.0.
- Updated the `Dockerfile` build stage base image from `golang:1.16` to `golang:1.23-alpine` to ensure builds use the modern standard library and toolchain enhancements.
- Ran `go mod tidy` to resolve dependency warnings.

## 3. Deprecation Fixes
**File involved:**
- `registry/registry.go`

Replaced the deprecated `ioutil.ReadAll` with `io.ReadAll`, in compliance with modern Go standards (Go 1.16+).

## 4. Unit Test Scaffolding
Added basic test scaffold files:
- `main_test.go`
- `registry/registry_test.go`
to establish a foundation for hitting the **70%+ test coverage milestone** in later phases.

# 🧪 Testing Performed
- ✅ `go build -o webhook .` completes successfully across the modernized toolchain.
- ✅ All external package dependencies pull without issue on Go 1.23.
- ✅ Local webhook startup verified via `make build-code`.